### PR TITLE
Add full-page jumbotron styles

### DIFF
--- a/css/full-page-jumbotron.css
+++ b/css/full-page-jumbotron.css
@@ -1,0 +1,66 @@
+/* NOTES:
+Because of the 'cascading' in Cascading Style Sheets, 
+the styles defined here will overwrite or modify any that are included before them.
+*/
+
+/* Header changes */
+header {
+    /* Makes header seem like part of the jumbotron */
+    position: absolute; 
+    /* Explicitly defining top and left can avoid a lot of weird behaviour on different browsers  */
+    top: 0;
+    left: 0;
+    /* Because it's position is absolute, you now have to force width */
+    width: 100%;
+}
+
+header .navbar.bg-dark {
+    /* Making the navbar see through lets the jumbtron picture give some texture */
+    background-image: linear-gradient( rgba(0,0,0,.9), rgba(0,0,0,.9) );
+    /* Overrides default bootstrap color */
+    background-color: rgba(0,0,0,.0) !important;
+} 
+
+/* Overrides default bootstrap color for collapsed section in header */
+header .collapse.bg-dark,
+header .collapsing.bg-dark  {
+    background-color: rgba(0,0,0,1) !important;
+}
+
+/* Main jumbotron changes */
+.jumbotron.main-jumbo {
+    /* This is the easiest way to align blocks vertically */
+    display: flex;
+    /* One of the most useful css things I've learned is how to add an overlay color to 
+    a background image. 
+    With a semi-transparent gradient you can keep the image but control the general color
+    to make text more visible, no matter what the image colors are. */
+    background-image: 
+        linear-gradient(
+            rgba(0,0,0,.6),
+            rgba(0,0,0,.8)
+        ), 
+        url("../img/jiafeng-wang-blackcar-shinyrims.jpg");
+    /* Forces jumbo to full screen height*/
+    min-height: 100vh;
+}
+
+/* Jumbotron Button changes */
+.jumbotron.main-jumbo .container {
+    /* Vertically centers this block(only works with a display: flex parent)  */
+    align-self: center;
+}
+
+.jumbotron.main-jumbo .container .btn {
+    /* Makes background visible */
+    background-color: rgba(0,0,0,.0);
+    font-size: 20px;
+}
+
+/* Ensures fade-in effet */
+.btn-success:hover {
+    background-color: #218838 !important;
+}
+.btn-primary:hover{
+    background-color: #0069d9 !important;
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     <!-- Custom styles for this template -->
     <link href="css/style.css" rel="stylesheet">
 
+    <!-- Custom styles for this template -->
+    <link href="css/full-page-jumbotron.css" rel="stylesheet">
+
     <!-- Font Awesome CDN-->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
 
@@ -50,13 +53,17 @@
     </header>
 
     <main role="main">
-      <section class="jumbotron text-center">
+      <section class="jumbotron main-jumbo text-center">
         <div class="container">
           <h1 class="jumbotron-heading">Ryan's Rim Restoration</h1>
           <p class="lead text-white">Like it never happened!</p>
           <p>
-            <a href="#" class="btn btn-success btn-large">Give us a call</a>
-            <a href="#" class="btn btn-primary btn-large">Send an Email</a>
+            <a href="#" class="btn btn-success btn-large">
+              <span class='fas fa-phone'></span> Give us a call
+            </a>
+            <a href="#" class="btn btn-primary btn-large">
+                <span class='fas fa-envelope'></span>  Send an Email
+            </a>
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Header
* Makes visible bar transparent
* Makes collapse solid black to make text more visible

## Jumbotron
* Adds dark overlay to make text more visible
* Makes full screen
* Centers btn container
* Makes btns see-through until hovered
* Adds font-awesome icons to btns